### PR TITLE
Update settings of favonia/cloudflare-ddns

### DIFF
--- a/cloudflare-ddns/docker-compose.yaml
+++ b/cloudflare-ddns/docker-compose.yaml
@@ -3,17 +3,13 @@ services:
   cloudflare-ddns:
     image: "favonia/cloudflare-ddns:latest"
     container_name: cloudflare-ddns
-    cap_add:
-      - SETUID
-      - SETGID
+    user: "${PUID}:${PGID}"
     cap_drop:
       - all
     read_only: true
     security_opt:
       - no-new-privileges:true
     environment:
-      - PUID=${PUID}
-      - PGID=${PGID}
       - CF_API_TOKEN=${CF_API_TOKEN}
       - DOMAINS=${DOMAINS}
       - PROXIED=${PROXIED}


### PR DESCRIPTION
Thanks for using my DDNS updater. Since [version 1.13.0 released on 16 July](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown#1130-2024-07-16), the updater has stopped dropping superuser privileges by itself, instead relying on Docker's built-in mechanism to drop those privileges. The new way is safer and more reliable, but it made the old Docker template (which grants `SETUID` and `SETGID`) potentially less secure. I am on a mission to eliminate the old template from the internet. Please help me promote security best practices!

For more information about this design change, please read the [CHANGELOG](https://github.com/favonia/cloudflare-ddns/blob/main/CHANGELOG.markdown). If copyright ever matters, this PR itself is licensed under [CC0](https://choosealicense.com/licenses/cc0-1.0/), which should allow you to do whatever you want. Thank you again for your interest in my DDNS updater.